### PR TITLE
fix: name browser variable consistently and properly

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ branding:
   icon: 'play'
   color: 'green'
 inputs:
-  browser-name:
+  browser:
     description: 'The browser against which to run tests, defaults to all if not provided'
     required: false
     default: 'all'
@@ -21,9 +21,9 @@ runs:
         node-version: 14
     - uses: c-hive/gha-yarn-cache@v1
     - run: yarn install
-    - run: npx playwright install-deps ${{ matrix.browser }}
+    - run: npx playwright install-deps ${{ inputs.browser }}
 
     # Directly runs the `yarn test` for this browser and return the value
     - id: test-runner
-      run: echo "::set-output name=test-output::$(yarn test --browserName=${{ inputs.browser-name }})"
+      run: echo "::set-output name=test-output::$(yarn test --browserName=${{ inputs.browser }})"
       shell: bash


### PR DESCRIPTION
Fixes the problem from the last PR where the browser name used `matrix`. Also just simplifies it.