### PR TITLE
test: install redirection

### DIFF
--- a/helpers/routes.ts
+++ b/helpers/routes.ts
@@ -7,6 +7,12 @@ const SUPPLIER = `${DOMAIN}/supplier`;
  */
 export const LOGIN_PAGE = `${DOMAIN}/login`;
 
+/**
+ * This must match the "App Url" setting of our Shopify App in order to test the
+ * userflow of embedded users.
+ */
+export const SK_APP_URL = `${DOMAIN}/shopkeep/inventory?embedded=true&canal_app_name=storefront`;
+
 export const SHOPKEEP_ROUTES = {
   INVENTORY: `${SHOPKEEP}/inventory`,
   DISCOVER: `${SHOPKEEP}/discover`,

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests here are meant to check that our install flow is working correctly, to
+ * the extent possible without manually going into Shopify with a test store.
+ */
+
+import { expect, test } from '@playwright/test';
+import { SK_APP_URL } from '../helpers/routes';
+
+const SHOPIFY_AUTH_URL_RE = /https:\/\/accounts.shopify.com\/lookup/;
+
+test.describe('Visit to the Shopify App Url', () => {
+  test.beforeEach(async ({ page }) => {
+    // Append query parameters to App URL just like Shopify would when
+    // redirecting users during an install.
+    const url = new URL(SK_APP_URL);
+    // hmac needs to be 64 characters long for our own FE validation.
+    url.searchParams.set(
+      'hmac',
+      '1234567890123456789012345678901234567890123456789012345678901234',
+    );
+    url.searchParams.set('host', 'anexamplehostvalue');
+    // Anything with a myshopify.com suffix works here.
+    url.searchParams.set('shop', 'canal-felipe-test-store.myshopify.com');
+    url.searchParams.set('timestamp', Date.now().toString());
+    await page.goto(url.toString());
+  });
+
+  test('sends users to Shopify login page', async ({ page }) => {
+    await expect(page).toHaveURL(SHOPIFY_AUTH_URL_RE);
+    await page.close();
+  });
+});


### PR DESCRIPTION
A test that would've caught the install break of last week (had we also modified the SK_APP_URL variable in `helper/routes.ts`)