### PR TITLE
fix: sk page after login changed

### DIFF
--- a/helpers/login.ts
+++ b/helpers/login.ts
@@ -13,39 +13,47 @@ const E2E_ACCOUNT_LOGIN = 'e2e_tester@shopcanal.com';
 
 /**
  * Use this to log a user in and make sure they land on a given page.
+ *
+ * @param loginUrl
+ * @param firstLoggedInPageUrl When passed, check that the user lands on this page.
  */
 const logIn = async (
   page: Page,
   context: BrowserContext,
   loginUrl: string,
-  firstLoggedInPageUrl: string,
+  firstLoggedInPageUrl: string | null = null,
 ): Promise<void> => {
   const loginButton = page.locator(LOGIN_BUTTON_SELECTOR);
   const profileDropdown = page.locator('button:has-text("e2e_tester")');
 
-  if (process.env.APP_TEST_PASSWORD) {
-    // Make sure browser is logged out before attempting to go through login flow
-    await logout(page, context);
-
-    // Navigate to login page and wait for login button to load
-    await page.goto(loginUrl);
-    await loginButton.waitFor();
-
-    // Fill out email and password
-    await page.fill(LOGIN_EMAIL_INPUT_SELECTOR, E2E_ACCOUNT_LOGIN);
-    await page.fill(LOGIN_PASSWORD_INPUT_SELECTOR, process.env.APP_TEST_PASSWORD || '');
-
-    // Then click the login button and make sure we navigate
-    await loginButton.click();
-
-    // Make sure the profile dropdown shows, as this appears on both sides once logged in
-    await profileDropdown.waitFor();
-
-    // Make sure this is the page we want
-    expect(page.url().includes(firstLoggedInPageUrl)).toBeTruthy();
-  } else {
+  if (!process.env.APP_TEST_PASSWORD) {
     console.warn('Could not log in because no APP_TEST_PASSWORD was provided. Failing test.');
     expect(true).toBe(false);
+  }
+
+  // Make sure browser is logged out before attempting to go through login flow
+  await logout(page, context);
+
+  // Navigate to login page and wait for login button to load
+  await page.goto(loginUrl);
+  await loginButton.waitFor();
+
+  // Fill out email and password
+  await page.fill(LOGIN_EMAIL_INPUT_SELECTOR, E2E_ACCOUNT_LOGIN);
+  await page.fill(LOGIN_PASSWORD_INPUT_SELECTOR, process.env.APP_TEST_PASSWORD || '');
+
+  // Then click the login button and make sure we navigate
+  await loginButton.click();
+
+  // Make sure the profile dropdown shows, as this appears on both sides once logged in
+  await profileDropdown.waitFor();
+
+  // Make sure we're no longer in the login
+  expect(page.url().includes(loginUrl)).toBeFalsy();
+
+  // Make sure this is the page we want
+  if (firstLoggedInPageUrl) {
+    expect(page.url().includes(firstLoggedInPageUrl)).toBeTruthy();
   }
 };
 
@@ -53,7 +61,7 @@ const logIn = async (
  * Logs a user into the shopkeep landing page
  */
 export const logIntoShopkeep = async (page: Page, context: BrowserContext): Promise<void> =>
-  logIn(page, context, SHOPKEEP_ROUTES.LOGIN, SHOPKEEP_ROUTES.INVENTORY);
+  logIn(page, context, SHOPKEEP_ROUTES.LOGIN);
 
 /**
  * Logs a user into the supplier landing page

--- a/helpers/routes.ts
+++ b/helpers/routes.ts
@@ -10,6 +10,7 @@ export const SK_APP_URL = `${DOMAIN}/shopkeep/inventory?embedded=true&canal_app_
 
 export const SHOPKEEP_ROUTES = {
   LOGIN: `${DOMAIN}/login`,
+  ROOT: SHOPKEEP,
   DISCOVER: `${SHOPKEEP}/discover`,
   INVENTORY: `${SHOPKEEP}/inventory`,
   SUPPLIERS: `${SHOPKEEP}/suppliers`,


### PR DESCRIPTION
A recent PR (https://github.com/shopcanal/frontend/pull/1044) in the frontend repo changed the login redirection logic to send users to either the invite brand or the inventory pages based on whether their inventory was empty or not.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202074041534561